### PR TITLE
Add SQLAlchemy data layer with models and repositories

### DIFF
--- a/crypto_bot/src/config/database_config.py
+++ b/crypto_bot/src/config/database_config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Database configuration settings."""
+from pydantic import BaseSettings, Field
+
+
+class DatabaseConfig(BaseSettings):
+    """Configuration for database connection parameters.
+
+    The settings are designed with high performance in mind and can be
+    extended via environment variables. Connection URL uses asyncpg driver.
+    """
+
+    database_url: str = Field(
+        default="postgresql+asyncpg://user:password@localhost:5432/crypto_bot",
+        description="Database connection URL",
+    )
+    pool_size: int = Field(default=10, description="Size of the connection pool")
+    max_overflow: int = Field(default=20, description="Maximum overflow connections")
+    pool_timeout: int = Field(
+        default=30, description="Timeout in seconds for obtaining a connection"
+    )
+    ssl_mode: str | None = Field(
+        default=None,
+        description="SSL mode for PostgreSQL. Use 'require' to enforce SSL",
+    )
+
+
+def get_database_config() -> DatabaseConfig:
+    """Return a configuration instance."""
+
+    return DatabaseConfig()

--- a/crypto_bot/src/data/__init__.py
+++ b/crypto_bot/src/data/__init__.py
@@ -1,0 +1,18 @@
+"""Data layer helpers including models, repositories and connections."""
+
+from .database import init_database, close_database, test_connection, get_sessionmaker
+from .redis_client import init_redis, close_redis, test_connection as test_redis, get_redis
+from . import models, repositories
+
+__all__ = [
+    "init_database",
+    "close_database",
+    "test_connection",
+    "get_sessionmaker",
+    "init_redis",
+    "close_redis",
+    "test_redis",
+    "get_redis",
+    "models",
+    "repositories",
+]

--- a/crypto_bot/src/data/database.py
+++ b/crypto_bot/src/data/database.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Database engine and session setup for the application."""
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy import text
+
+from config.database_config import get_database_config
+
+_engine: AsyncEngine | None = None
+_sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+
+class Base(DeclarativeBase):
+    """Base class for all models.
+
+    This class exists here to make type checkers happy when importing from
+    database module. The real Base with timestamp columns is defined in
+    ``data/models/base_model.py`` and should inherit from this one.
+    """
+
+
+async def init_database() -> None:
+    """Initialize database engine and session factory."""
+
+    global _engine, _sessionmaker
+    if _engine is not None:
+        return
+
+    config = get_database_config()
+    connect_args = {}
+    if config.ssl_mode:
+        connect_args["ssl"] = config.ssl_mode
+
+    _engine = create_async_engine(
+        config.database_url,
+        echo=False,
+        pool_size=config.pool_size,
+        max_overflow=config.max_overflow,
+        pool_timeout=config.pool_timeout,
+        connect_args=connect_args,
+    )
+    _sessionmaker = async_sessionmaker(bind=_engine, expire_on_commit=False)
+
+
+async def close_database() -> None:
+    """Dispose the engine and close all connections."""
+
+    global _engine, _sessionmaker
+    if _sessionmaker is not None:
+        _sessionmaker.close_all()  # type: ignore[func-returns-value]
+        _sessionmaker = None
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+
+
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    if _sessionmaker is None:
+        raise RuntimeError("Database is not initialized")
+    return _sessionmaker
+
+
+async def test_connection() -> bool:
+    """Test database connectivity by executing a simple query."""
+
+    if _engine is None:
+        await init_database()
+    assert _engine is not None
+    try:
+        async with _engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False

--- a/crypto_bot/src/data/migrations.py
+++ b/crypto_bot/src/data/migrations.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Database migration helpers."""
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from data.models import BaseModel, User, Pair
+from data.database import init_database, get_sessionmaker
+
+
+async def create_all_tables(engine: AsyncEngine | None = None) -> None:
+    """Create all database tables."""
+
+    if engine is None:
+        await init_database()
+        engine = get_sessionmaker().bind  # type: ignore[attr-defined]
+    assert engine is not None
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseModel.metadata.create_all)
+
+
+async def drop_all_tables(engine: AsyncEngine | None = None) -> None:
+    if engine is None:
+        await init_database()
+        engine = get_sessionmaker().bind  # type: ignore[attr-defined]
+    assert engine is not None
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseModel.metadata.drop_all)
+
+
+async def init_sample_data() -> None:
+    """Insert minimal sample data for tests."""
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        user_repo = User(id=1, username="test")
+        pair_repo = Pair(symbol="BTCUSDT", base_asset="BTC", quote_asset="USDT")
+        session.add_all([user_repo, pair_repo])
+        await session.commit()

--- a/crypto_bot/src/data/models/__init__.py
+++ b/crypto_bot/src/data/models/__init__.py
@@ -1,0 +1,17 @@
+"""SQLAlchemy models package."""
+
+from .base_model import BaseModel
+from .user_model import User
+from .pair_model import Pair
+from .user_pair_model import UserPair
+from .candle_model import Candle
+from .signal_history_model import SignalHistory
+
+__all__ = [
+    "BaseModel",
+    "User",
+    "Pair",
+    "UserPair",
+    "Candle",
+    "SignalHistory",
+]

--- a/crypto_bot/src/data/models/base_model.py
+++ b/crypto_bot/src/data/models/base_model.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Base model containing timestamp columns."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from data.database import Base
+
+
+class TimestampMixin:
+    """Mixin providing created_at and updated_at columns."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class BaseModel(Base, TimestampMixin):
+    """Declarative base model for all ORM models."""
+
+    __abstract__ = True

--- a/crypto_bot/src/data/models/candle_model.py
+++ b/crypto_bot/src/data/models/candle_model.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Candle (OHLCV) data model."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, ForeignKey, Integer, String, Float, DateTime, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base_model import BaseModel
+
+
+class Candle(BaseModel):
+    """Stores OHLCV data for trading pairs."""
+
+    __tablename__ = "candles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    pair_id: Mapped[int] = mapped_column(ForeignKey("pairs.id"), nullable=False)
+    timeframe: Mapped[str] = mapped_column(String(10), nullable=False)
+    open_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    close_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    open_price: Mapped[float] = mapped_column(Float, nullable=False)
+    high_price: Mapped[float] = mapped_column(Float, nullable=False)
+    low_price: Mapped[float] = mapped_column(Float, nullable=False)
+    close_price: Mapped[float] = mapped_column(Float, nullable=False)
+    volume: Mapped[float] = mapped_column(Float, nullable=False)
+    quote_volume: Mapped[float] = mapped_column(Float, nullable=False)
+    is_closed: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    pair: Mapped["Pair"] = relationship(back_populates="candles")
+
+    __table_args__ = (
+        Index("ix_candles_pair_tf_open", "pair_id", "timeframe", "open_time"),
+        Index("ix_candles_open_time", "open_time"),
+    )

--- a/crypto_bot/src/data/models/pair_model.py
+++ b/crypto_bot/src/data/models/pair_model.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Trading pair model."""
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+from sqlalchemy import Boolean, Integer, String, Float, DateTime, JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base_model import BaseModel
+
+
+class Pair(BaseModel):
+    """Represents a trading pair (e.g., BTCUSDT)."""
+
+    __tablename__ = "pairs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(20), unique=True, nullable=False)
+    base_asset: Mapped[str] = mapped_column(String(20), nullable=False)
+    quote_asset: Mapped[str] = mapped_column(String(20), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_tracked: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    users_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    signals_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    last_price: Mapped[Optional[float]] = mapped_column(Float)
+    last_update_time: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    real_time_monitoring: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    performance_metrics: Mapped[Dict[str, Any] | None] = mapped_column(JSON, default=dict)
+
+    user_pairs: Mapped[list["UserPair"]] = relationship(back_populates="pair")
+    signal_history: Mapped[list["SignalHistory"]] = relationship(back_populates="pair")
+    candles: Mapped[list["Candle"]] = relationship(back_populates="pair")
+
+    @staticmethod
+    def validate_symbol(symbol: str) -> bool:
+        """Validate trading pair symbol."""
+
+        return symbol.isupper() and len(symbol) >= 6
+
+    def update_statistics(self, users_delta: int = 0, signals_delta: int = 0) -> None:
+        """Update counts for users and signals."""
+
+        self.users_count += users_delta
+        self.signals_count += signals_delta
+
+    def activate_monitoring(self) -> None:
+        self.real_time_monitoring = True
+
+    def deactivate_monitoring(self) -> None:
+        self.real_time_monitoring = False

--- a/crypto_bot/src/data/models/signal_history_model.py
+++ b/crypto_bot/src/data/models/signal_history_model.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Model storing history of generated signals."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base_model import BaseModel
+
+
+class SignalHistory(BaseModel):
+    """Represents history of alerts sent to users."""
+
+    __tablename__ = "signal_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    pair_id: Mapped[int] = mapped_column(ForeignKey("pairs.id"), nullable=False)
+    timeframe: Mapped[str] = mapped_column(String(10), nullable=False)
+    signal_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    signal_value: Mapped[float | None] = mapped_column(Float)
+    price: Mapped[float | None] = mapped_column(Float)
+    volume_change: Mapped[float | None] = mapped_column(Float)
+    sent_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default="now()")
+    processing_time_ms: Mapped[int | None] = mapped_column(Integer)
+    delivery_time_ms: Mapped[int | None] = mapped_column(Integer)
+
+    user: Mapped["User"] = relationship(back_populates="signal_history")
+    pair: Mapped["Pair"] = relationship(back_populates="signal_history")

--- a/crypto_bot/src/data/models/user_model.py
+++ b/crypto_bot/src/data/models/user_model.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""User model definition."""
+
+from typing import Any, Dict, Optional
+
+from sqlalchemy import BigInteger, Boolean, Integer, String, JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base_model import BaseModel
+
+
+class User(BaseModel):
+    """Telegram user representation."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    username: Mapped[Optional[str]] = mapped_column(String(50))
+    first_name: Mapped[Optional[str]] = mapped_column(String(100))
+    last_name: Mapped[Optional[str]] = mapped_column(String(100))
+    language_code: Mapped[Optional[str]] = mapped_column(String(10))
+    notifications_enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_blocked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    total_signals_received: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    real_time_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    real_time_performance_stats: Mapped[Dict[str, Any] | None] = mapped_column(JSON, default=dict)
+
+    # relationships
+    user_pairs: Mapped[list["UserPair"]] = relationship(back_populates="user")
+    signal_history: Mapped[list["SignalHistory"]] = relationship(back_populates="user")
+
+    @property
+    def display_name(self) -> str:
+        """Return a human friendly display name."""
+
+        return self.username or " ".join(filter(None, [self.first_name, self.last_name]))
+
+    def update_from_telegram(self, telegram_user: Any) -> None:
+        """Update fields based on Telegram user object."""
+
+        self.id = telegram_user.id
+        self.username = getattr(telegram_user, "username", None)
+        self.first_name = getattr(telegram_user, "first_name", None)
+        self.last_name = getattr(telegram_user, "last_name", None)
+        self.language_code = getattr(telegram_user, "language_code", None)
+
+    def toggle_notifications(self) -> bool:
+        """Toggle notifications and return new state."""
+
+        self.notifications_enabled = not self.notifications_enabled
+        return self.notifications_enabled
+
+    def increment_signals_count(self) -> None:
+        """Increment count of received signals."""
+
+        self.total_signals_received += 1
+
+    def enable_real_time_monitoring(self) -> None:
+        """Enable real-time monitoring for user."""
+
+        self.real_time_enabled = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize model to dictionary."""
+
+        return {
+            "id": self.id,
+            "username": self.username,
+            "first_name": self.first_name,
+            "last_name": self.last_name,
+            "language_code": self.language_code,
+            "notifications_enabled": self.notifications_enabled,
+            "is_active": self.is_active,
+            "is_blocked": self.is_blocked,
+            "total_signals_received": self.total_signals_received,
+            "real_time_enabled": self.real_time_enabled,
+            "real_time_performance_stats": self.real_time_performance_stats,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }

--- a/crypto_bot/src/data/models/user_pair_model.py
+++ b/crypto_bot/src/data/models/user_pair_model.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Association table between users and trading pairs."""
+
+from datetime import datetime
+from typing import Dict, Any
+
+from sqlalchemy import Boolean, ForeignKey, Integer, JSON, DateTime
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base_model import BaseModel
+
+
+class UserPair(BaseModel):
+    """Link between User and Pair with settings."""
+
+    __tablename__ = "user_pairs"
+
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), primary_key=True)
+    pair_id: Mapped[int] = mapped_column(ForeignKey("pairs.id"), primary_key=True)
+    timeframes: Mapped[Dict[str, Any] | None] = mapped_column(JSON, default=dict)
+    signals_received: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    custom_settings: Mapped[Dict[str, Any] | None] = mapped_column(JSON, default=dict)
+    real_time_active: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    last_signal_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    user: Mapped["User"] = relationship(back_populates="user_pairs")
+    pair: Mapped["Pair"] = relationship(back_populates="user_pairs")

--- a/crypto_bot/src/data/redis_client.py
+++ b/crypto_bot/src/data/redis_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Redis client with connection pooling and health checks."""
+
+from typing import Optional
+
+import asyncio
+import redis.asyncio as redis
+
+_redis: Optional[redis.Redis] = None
+
+
+async def init_redis(url: str = "redis://localhost:6379/0") -> None:
+    """Initialize global Redis client."""
+
+    global _redis
+    if _redis is None:
+        _redis = redis.from_url(url, decode_responses=True)
+        try:
+            await _redis.ping()
+        except Exception:
+            _redis = None
+            raise
+
+
+async def close_redis() -> None:
+    """Close the Redis connection."""
+
+    global _redis
+    if _redis is not None:
+        await _redis.close()
+        _redis = None
+
+
+def get_redis() -> redis.Redis:
+    if _redis is None:
+        raise RuntimeError("Redis is not initialized")
+    return _redis
+
+
+async def test_connection() -> bool:
+    try:
+        client = get_redis()
+        await client.ping()
+        return True
+    except Exception:
+        return False

--- a/crypto_bot/src/data/repositories/__init__.py
+++ b/crypto_bot/src/data/repositories/__init__.py
@@ -1,0 +1,13 @@
+"""Repository package."""
+
+from .base_repository import BaseRepository
+from .user_repository import UserRepository
+from .pair_repository import PairRepository
+from .signal_repository import SignalRepository
+
+__all__ = [
+    "BaseRepository",
+    "UserRepository",
+    "PairRepository",
+    "SignalRepository",
+]

--- a/crypto_bot/src/data/repositories/base_repository.py
+++ b/crypto_bot/src/data/repositories/base_repository.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Generic asynchronous repository with CRUD operations."""
+
+from typing import Any, Generic, Iterable, List, Optional, Sequence, Type, TypeVar
+from time import perf_counter
+
+from sqlalchemy import update, select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from data.models import BaseModel
+
+ModelType = TypeVar("ModelType", bound=BaseModel)
+
+
+class BaseRepository(Generic[ModelType]):
+    """Base repository providing common CRUD helpers."""
+
+    def __init__(self, model: Type[ModelType]):
+        self.model = model
+
+    async def create(self, session: AsyncSession, obj_in: dict[str, Any]) -> ModelType:
+        obj = self.model(**obj_in)
+        session.add(obj)
+        await session.flush()
+        return obj
+
+    async def get_by_id(self, session: AsyncSession, obj_id: Any) -> Optional[ModelType]:
+        result = await session.execute(select(self.model).where(self.model.id == obj_id))
+        return result.scalar_one_or_none()
+
+    async def get_all(self, session: AsyncSession) -> Sequence[ModelType]:
+        result = await session.execute(select(self.model))
+        return result.scalars().all()
+
+    async def update(self, session: AsyncSession, obj_id: Any, obj_in: dict[str, Any]) -> Optional[ModelType]:
+        await session.execute(
+            update(self.model).where(self.model.id == obj_id).values(**obj_in)
+        )
+        await session.flush()
+        return await self.get_by_id(session, obj_id)
+
+    async def delete(self, session: AsyncSession, obj_id: Any) -> None:
+        await session.execute(delete(self.model).where(self.model.id == obj_id))
+
+    async def bulk_create(self, session: AsyncSession, objs_in: Iterable[dict[str, Any]]) -> List[ModelType]:
+        objs = [self.model(**data) for data in objs_in]
+        session.add_all(objs)
+        await session.flush()
+        return objs
+
+    async def get_with_performance_tracking(
+        self, session: AsyncSession, obj_id: Any
+    ) -> tuple[Optional[ModelType], int]:
+        """Fetch object by id and return time taken in milliseconds."""
+
+        start = perf_counter()
+        obj = await self.get_by_id(session, obj_id)
+        elapsed_ms = int((perf_counter() - start) * 1000)
+        return obj, elapsed_ms
+
+    async def bulk_update_optimized(
+        self, session: AsyncSession, mappings: Iterable[dict[str, Any]]
+    ) -> None:
+        """Perform optimized bulk update using mappings."""
+
+        await session.bulk_update_mappings(self.model, list(mappings))

--- a/crypto_bot/src/data/repositories/pair_repository.py
+++ b/crypto_bot/src/data/repositories/pair_repository.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Repository for :class:`Pair` model."""
+
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .base_repository import BaseRepository
+from data.models import Pair
+
+
+class PairRepository(BaseRepository[Pair]):
+    def __init__(self) -> None:
+        super().__init__(Pair)
+
+    async def get_by_symbol(self, session: AsyncSession, symbol: str) -> Optional[Pair]:
+        result = await session.execute(select(Pair).where(Pair.symbol == symbol))
+        return result.scalar_one_or_none()
+
+    async def get_active_pairs(self, session: AsyncSession) -> List[Pair]:
+        result = await session.execute(select(Pair).where(Pair.is_active.is_(True)))
+        return result.scalars().all()
+
+    async def get_pairs_for_real_time_monitoring(
+        self, session: AsyncSession
+    ) -> List[Pair]:
+        result = await session.execute(
+            select(Pair).where(Pair.real_time_monitoring.is_(True))
+        )
+        return result.scalars().all()

--- a/crypto_bot/src/data/repositories/signal_repository.py
+++ b/crypto_bot/src/data/repositories/signal_repository.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Repository for :class:`SignalHistory` model."""
+
+from typing import List
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .base_repository import BaseRepository
+from data.models import SignalHistory
+
+
+class SignalRepository(BaseRepository[SignalHistory]):
+    def __init__(self) -> None:
+        super().__init__(SignalHistory)
+
+    async def get_recent_signals(
+        self, session: AsyncSession, limit: int = 100
+    ) -> List[SignalHistory]:
+        result = await session.execute(
+            select(SignalHistory).order_by(SignalHistory.sent_at.desc()).limit(limit)
+        )
+        return result.scalars().all()
+
+    async def get_performance_stats(self, session: AsyncSession) -> dict[str, float]:
+        result = await session.execute(
+            select(
+                func.avg(SignalHistory.processing_time_ms),
+                func.avg(SignalHistory.delivery_time_ms),
+            )
+        )
+        avg_processing, avg_delivery = result.one()
+        return {
+            "avg_processing_ms": float(avg_processing or 0),
+            "avg_delivery_ms": float(avg_delivery or 0),
+        }

--- a/crypto_bot/src/data/repositories/user_repository.py
+++ b/crypto_bot/src/data/repositories/user_repository.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Repository for :class:`User` model."""
+
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .base_repository import BaseRepository
+from data.models import User
+
+
+class UserRepository(BaseRepository[User]):
+    def __init__(self) -> None:
+        super().__init__(User)
+
+    async def get_by_telegram_id(
+        self, session: AsyncSession, telegram_id: int
+    ) -> Optional[User]:
+        result = await session.execute(
+            select(User).where(User.id == telegram_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_active_users(self, session: AsyncSession) -> List[User]:
+        result = await session.execute(select(User).where(User.is_active.is_(True)))
+        return result.scalars().all()
+
+    async def get_users_with_real_time(self, session: AsyncSession) -> List[User]:
+        result = await session.execute(
+            select(User).where(User.real_time_enabled.is_(True))
+        )
+        return result.scalars().all()


### PR DESCRIPTION
## Summary
- add async PostgreSQL engine and Redis client helpers
- implement core SQLAlchemy models with real-time fields and repositories
- provide configuration, migrations utilities, and CRUD base repository

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b54376138832bb8838cab8b3e663c