### PR TITLE
feat: add initial telegram bot interface

### DIFF
--- a/crypto_bot/src/bot/handlers/add_pair/add_pair_handler.py
+++ b/crypto_bot/src/bot/handlers/add_pair/add_pair_handler.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Handlers for adding trading pairs."""
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.bot_config import BotConfig
+from .add_pair_logic import execute_add_pair, process_symbol_input
+
+add_pair_router = Router()
+config = BotConfig()
+
+
+class AddPairStates(StatesGroup):
+    waiting_for_symbol = State()
+    confirming_pair = State()
+
+
+def register_add_pair_handlers(dp) -> None:  # type: ignore[override]
+    dp.include_router(add_pair_router)
+
+
+@add_pair_router.callback_query(F.data == "add_pair")
+async def start_add_pair(callback: CallbackQuery, state: FSMContext) -> None:
+    await callback.message.answer("Введите символ торговой пары (например BTCUSDT):")
+    await state.set_state(AddPairStates.waiting_for_symbol)
+    await callback.answer()
+
+
+@add_pair_router.message(AddPairStates.waiting_for_symbol)
+async def process_symbol_message(message: Message, state: FSMContext) -> None:
+    symbol = message.text or ""
+    result = await process_symbol_input(symbol)
+    if not result["valid"]:
+        await message.answer(result["error"])
+        return
+    await state.update_data(symbol=result["pair_info"]["symbol"])
+    await message.answer(
+        f"Добавить пару {result['pair_info']['symbol']}?", reply_markup=None
+    )
+    await state.set_state(AddPairStates.confirming_pair)
+
+
+@add_pair_router.callback_query(AddPairStates.confirming_pair, F.data == "confirm_add_pair")
+async def confirm_add_pair(
+    callback: CallbackQuery, state: FSMContext, session: AsyncSession
+) -> None:
+    data = await state.get_data()
+    symbol = data.get("symbol")
+    if not symbol:
+        await callback.answer("Символ не найден", show_alert=True)
+        return
+    user = callback.from_user
+    pair = await execute_add_pair(session, user, symbol)  # type: ignore[arg-type]
+    await session.commit()
+    await callback.message.answer(f"Пара {pair.symbol} добавлена")
+    await state.clear()
+    await callback.answer()

--- a/crypto_bot/src/bot/handlers/add_pair/add_pair_logic.py
+++ b/crypto_bot/src/bot/handlers/add_pair/add_pair_logic.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Business logic for adding new trading pairs."""
+
+from typing import Any, Dict
+
+import httpx
+
+from config.bot_config import BotConfig
+from data.models import Pair
+from data.repositories.pair_repository import PairRepository
+from data.repositories.user_pair_repository import UserPairRepository
+from utils.validators import normalize_trading_symbol, validate_trading_pair_symbol
+
+config = BotConfig()
+pair_repository = PairRepository()
+user_pair_repository = UserPairRepository()
+
+
+async def process_symbol_input(symbol: str) -> Dict[str, Any]:
+    """Validate and fetch information about ``symbol`` from Binance API."""
+
+    if not validate_trading_pair_symbol(symbol):
+        return {"valid": False, "pair_info": None, "error": "Некорректный символ"}
+
+    normalized = normalize_trading_symbol(symbol)
+    url = "https://api.binance.com/api/v3/exchangeInfo"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params={"symbol": normalized})
+    if resp.status_code != 200:
+        return {"valid": False, "pair_info": None, "error": "Пара не найдена"}
+    data = resp.json().get("symbols", [])
+    if not data:
+        return {"valid": False, "pair_info": None, "error": "Пара недоступна"}
+    info = data[0]
+    return {
+        "valid": True,
+        "pair_info": {
+            "symbol": info["symbol"],
+            "base_asset": info["baseAsset"],
+            "quote_asset": info["quoteAsset"],
+        },
+        "error": "",
+    }
+
+
+async def execute_add_pair(
+    session, user, symbol: str
+) -> Pair:  # type: ignore[valid-type]
+    """Create pair and user relation with default settings."""
+
+    normalized = normalize_trading_symbol(symbol)
+    pair = await pair_repository.get_by_symbol(session, normalized)
+    if not pair:
+        pair = await pair_repository.create(session, {"symbol": normalized})
+    timeframes = {tf: True for tf in config.default_timeframes}
+    await user_pair_repository.create(
+        session,
+        {
+            "user_id": user.id,
+            "pair_id": pair.id,
+            "timeframes": timeframes,
+            "real_time_active": config.real_time_enabled,
+        },
+    )
+    return pair

--- a/crypto_bot/src/bot/handlers/my_pairs/my_pairs_formatters.py
+++ b/crypto_bot/src/bot/handlers/my_pairs/my_pairs_formatters.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Formatting helpers for the ``my_pairs`` handlers."""
+
+from typing import Any, Dict, List
+
+from utils.time_helpers import format_datetime
+
+
+def create_pairs_list_message(user_pairs: List[Dict[str, Any]]) -> str:
+    message = "📊 <b>Ваши торговые пары:</b>\n\n"
+    for pair_data in user_pairs:
+        symbol = pair_data["symbol"]
+        signals_count = pair_data.get("signals_count", 0)
+        last_signal = pair_data.get("last_signal_time")
+        real_time_status = (
+            "⚡ Активно" if pair_data.get("real_time_active") else "⏸ Пауза"
+        )
+        message += f"💰 <b>{symbol}</b>\n"
+        message += f"📈 Сигналов: {signals_count}\n"
+        message += f"🔥 Реальное время: {real_time_status}\n"
+        if last_signal:
+            message += f"🕐 Последний: {format_datetime(last_signal)}\n"
+        message += "\n"
+    return message
+
+
+def create_real_time_performance_message(stats: Dict[str, Any]) -> str:
+    """Create a simple text representation of performance metrics."""
+
+    lines = ["⚡ <b>Производительность реального времени</b>"]
+    for key, value in stats.items():
+        lines.append(f"{key}: {value}")
+    return "\n".join(lines)

--- a/crypto_bot/src/bot/handlers/my_pairs/my_pairs_handler.py
+++ b/crypto_bot/src/bot/handlers/my_pairs/my_pairs_handler.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Handlers for managing user's trading pairs."""
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.cache.indicator_cache import indicator_cache
+from .my_pairs_formatters import (
+    create_pairs_list_message,
+    create_real_time_performance_message,
+)
+from .my_pairs_keyboards import (
+    create_pair_management_keyboard,
+    create_real_time_status_keyboard,
+)
+
+my_pairs_router = Router()
+
+
+class MyPairsStates(StatesGroup):
+    viewing_pairs = State()
+    managing_timeframes = State()
+    viewing_rsi = State()
+    viewing_real_time_status = State()
+
+
+def register_my_pairs_handlers(dp) -> None:  # type: ignore[override]
+    dp.include_router(my_pairs_router)
+
+
+@my_pairs_router.callback_query(F.data == "my_pairs")
+async def show_user_pairs(callback: CallbackQuery, state: FSMContext, session: AsyncSession) -> None:
+    # Placeholder: repository method not implemented, send empty list
+    user_pairs: list[dict] = []
+    text = (
+        create_pairs_list_message(user_pairs)
+        if user_pairs
+        else "У вас пока нет добавленных пар"
+    )
+    await callback.message.answer(text)
+    await state.set_state(MyPairsStates.viewing_pairs)
+    await callback.answer()
+
+
+@my_pairs_router.callback_query(MyPairsStates.viewing_pairs)
+async def manage_pair(callback: CallbackQuery, state: FSMContext) -> None:
+    # Expect callback data like "pair:<id>"
+    parts = (callback.data or "").split(":")
+    if len(parts) != 2:
+        await callback.answer()
+        return
+    pair_id = int(parts[1])
+    await callback.message.answer(
+        "Управление парой",
+        reply_markup=create_pair_management_keyboard(pair_id),
+    )
+    await callback.answer()
+
+
+@my_pairs_router.callback_query(MyPairsStates.viewing_rsi)
+async def show_rsi_values(callback: CallbackQuery, state: FSMContext) -> None:
+    data = await state.get_data()
+    pair_id = data.get("pair_id")
+    rsi_values = indicator_cache.get_rsi(pair_id) if pair_id else {}
+    lines = [f"RSI {tf}: {value}" for tf, value in rsi_values.items()]
+    await callback.message.answer("\n".join(lines) or "Нет данных")
+    await callback.answer()
+
+
+@my_pairs_router.callback_query(MyPairsStates.viewing_real_time_status)
+async def show_real_time_status(callback: CallbackQuery, state: FSMContext) -> None:
+    data = await state.get_data()
+    pair_id = data.get("pair_id")
+    stats = {}  # Placeholder for performance stats
+    text = create_real_time_performance_message(stats)
+    await callback.message.answer(
+        text, reply_markup=create_real_time_status_keyboard(pair_id or 0, True)
+    )
+    await callback.answer()

--- a/crypto_bot/src/bot/handlers/my_pairs/my_pairs_keyboards.py
+++ b/crypto_bot/src/bot/handlers/my_pairs/my_pairs_keyboards.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Keyboards for managing user pairs."""
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from utils.constants import EMOJI
+
+
+def create_pair_management_keyboard(pair_id: int) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.row(
+        InlineKeyboardButton(text="📊 RSI значения", callback_data=f"rsi:{pair_id}"),
+        InlineKeyboardButton(text="⚙️ Таймфреймы", callback_data=f"tf:{pair_id}"),
+    )
+    builder.row(
+        InlineKeyboardButton(text="⚡ Реальное время", callback_data=f"rt:{pair_id}"),
+        InlineKeyboardButton(text="📈 Производительность", callback_data=f"perf:{pair_id}"),
+    )
+    builder.row(
+        InlineKeyboardButton(text="❌ Удалить пару", callback_data=f"del:{pair_id}"),
+        InlineKeyboardButton(text="🔙 Назад", callback_data="my_pairs"),
+    )
+    return builder.as_markup()
+
+
+def create_real_time_status_keyboard(pair_id: int, active: bool) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    toggle = "⏸ Пауза" if active else "▶️ Возобновить"
+    builder.row(
+        InlineKeyboardButton(text=toggle, callback_data=f"toggle_rt:{pair_id}"),
+        InlineKeyboardButton(text="📊 Метрики", callback_data=f"metrics:{pair_id}"),
+    )
+    builder.row(
+        InlineKeyboardButton(text="🔧 Настройки", callback_data=f"rt_settings:{pair_id}"),
+        InlineKeyboardButton(text="🔙 Назад", callback_data="my_pairs"),
+    )
+    return builder.as_markup()

--- a/crypto_bot/src/bot/handlers/remove_pair_handler.py
+++ b/crypto_bot/src/bot/handlers/remove_pair_handler.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Handlers for removing trading pairs."""
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from data.repositories.user_pair_repository import UserPairRepository
+from services.websocket.stream_manager import StreamManager
+
+remove_pair_router = Router()
+user_pair_repository = UserPairRepository()
+stream_manager: StreamManager | None = None
+
+
+class RemovePairStates(StatesGroup):
+    selecting_pair = State()
+    confirming_removal = State()
+
+
+def register_remove_pair_handlers(dp) -> None:  # type: ignore[override]
+    dp.include_router(remove_pair_router)
+
+
+@remove_pair_router.callback_query(F.data == "remove_pair")
+async def choose_pair_to_remove(callback: CallbackQuery, state: FSMContext) -> None:
+    await callback.message.answer("Выберите пару для удаления (пока заглушка)")
+    await state.set_state(RemovePairStates.selecting_pair)
+    await callback.answer()
+
+
+async def execute_pair_removal(
+    session: AsyncSession, user_id: int, pair_id: int
+) -> None:
+    await user_pair_repository.delete(session, pair_id)
+    if stream_manager:
+        await stream_manager.update_subscriptions()
+
+
+@remove_pair_router.callback_query(RemovePairStates.confirming_removal)
+async def confirm_removal(
+    callback: CallbackQuery, state: FSMContext, session: AsyncSession
+) -> None:
+    data = await state.get_data()
+    pair_id = data.get("pair_id")
+    if not pair_id:
+        await callback.answer("Пара не найдена", show_alert=True)
+        return
+    await execute_pair_removal(session, callback.from_user.id, pair_id)
+    await session.commit()
+    await callback.message.answer("Пара удалена")
+    await state.clear()
+    await callback.answer()

--- a/crypto_bot/src/bot/handlers/start_handler.py
+++ b/crypto_bot/src/bot/handlers/start_handler.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+"""Handlers for the ``/start`` command."""
+
+from typing import Any, Dict, Tuple
+
+from aiogram import Router
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.bot_config import BotConfig
+from data.models import User
+from data.repositories.pair_repository import PairRepository
+from data.repositories.user_pair_repository import UserPairRepository
+from data.repositories.user_repository import UserRepository
+from services.websocket.stream_manager import StreamManager
+from bot.keyboards.main_menu_kb import get_main_menu_keyboard
+
+start_router = Router()
+
+user_repository = UserRepository()
+pair_repository = PairRepository()
+user_pair_repository = UserPairRepository()
+config = BotConfig()
+
+# Global instance, expected to be set on application init
+stream_manager: StreamManager | None = None
+
+
+def register_start_handlers(dp) -> None:  # type: ignore[override]
+    """Register start command handlers."""
+
+    dp.include_router(start_router)
+
+
+async def get_or_create_user(
+    session: AsyncSession, telegram_user: Any
+) -> Tuple[User, bool]:
+    """Fetch existing user or create a new one."""
+
+    user = await user_repository.get_by_telegram_id(session, telegram_user.id)
+    created = False
+    if not user:
+        data: Dict[str, Any] = {
+            "id": telegram_user.id,
+            "username": telegram_user.username,
+            "first_name": telegram_user.first_name,
+            "last_name": telegram_user.last_name,
+            "language_code": telegram_user.language_code,
+        }
+        user = await user_repository.create(session, data)
+        created = True
+    else:
+        user.update_from_telegram(telegram_user)
+    return user, created
+
+
+async def setup_default_pair_for_user(
+    session: AsyncSession, user: User
+) -> None:
+    """Create default trading pair for ``user`` if missing."""
+
+    symbol = config.default_pair
+    pair = await pair_repository.get_by_symbol(session, symbol)
+    if not pair:
+        pair = await pair_repository.create(session, {"symbol": symbol})
+    timeframes = {tf: True for tf in config.default_timeframes}
+    await user_pair_repository.create(
+        session,
+        {
+            "user_id": user.id,
+            "pair_id": pair.id,
+            "timeframes": timeframes,
+            "real_time_active": config.real_time_enabled,
+        },
+    )
+
+    if config.real_time_enabled and stream_manager:
+        await stream_manager.add_symbol_stream(symbol, config.default_timeframes)
+
+
+async def initialize_real_time_monitoring(user: User) -> None:
+    """Enable real-time monitoring for the user if configured."""
+
+    if not config.real_time_enabled:
+        return
+    user.enable_real_time_monitoring()
+
+
+def create_welcome_message(user: User) -> str:
+    return (
+        "👋 Привет, {name}!\n"
+        "Мы настроили для тебя пару по умолчанию {pair}."
+    ).format(name=user.display_name, pair=config.default_pair)
+
+
+def create_welcome_back_message(user: User) -> str:
+    return f"С возвращением, {user.display_name}!"
+
+
+@start_router.message(CommandStart())
+async def handle_start_command(
+    message: Message, session: AsyncSession, state: FSMContext
+) -> None:
+    """Handle the ``/start`` command."""
+
+    telegram_user = message.from_user
+    if telegram_user is None:
+        return
+
+    user, created = await get_or_create_user(session, telegram_user)
+    if created:
+        await setup_default_pair_for_user(session, user)
+        greeting = create_welcome_message(user)
+    else:
+        greeting = create_welcome_back_message(user)
+
+    await initialize_real_time_monitoring(user)
+    await session.commit()
+
+    await message.answer(
+        greeting, reply_markup=get_main_menu_keyboard(user.real_time_enabled)
+    )

--- a/crypto_bot/src/bot/keyboards/main_menu_kb.py
+++ b/crypto_bot/src/bot/keyboards/main_menu_kb.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Inline keyboards for the main bot menu."""
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_main_menu_keyboard(real_time_enabled: bool = False) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.row(
+        InlineKeyboardButton(text="➕ Добавить пару", callback_data="add_pair"),
+        InlineKeyboardButton(text="📊 Мои пары", callback_data="my_pairs"),
+    )
+    builder.row(
+        InlineKeyboardButton(text="❌ Удалить пару", callback_data="remove_pair"),
+        InlineKeyboardButton(text="⚙️ Настройки", callback_data="settings"),
+    )
+    if real_time_enabled:
+        rt_status = "⚡ Реальное время: ВКЛ"
+        builder.row(InlineKeyboardButton(text=rt_status, callback_data="real_time_status"))
+    return builder.as_markup()
+
+
+def get_real_time_controls_keyboard(active: bool) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    toggle = "⏸ Пауза" if active else "▶️ Возобновить"
+    builder.row(
+        InlineKeyboardButton(text="📊 Производительность", callback_data="rt_metrics"),
+        InlineKeyboardButton(text="⚙️ Настройки RT", callback_data="rt_settings"),
+    )
+    builder.row(InlineKeyboardButton(text=toggle, callback_data="rt_toggle"))
+    builder.row(InlineKeyboardButton(text="🔧 Диагностика", callback_data="rt_diag"))
+    return builder.as_markup()
+
+
+def get_settings_keyboard() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.row(
+        InlineKeyboardButton(text="🔔 Уведомления", callback_data="notif"),
+        InlineKeyboardButton(text="🕐 Интервалы", callback_data="intervals"),
+    )
+    builder.row(
+        InlineKeyboardButton(text="⚡ Реальное время", callback_data="rt_settings"),
+        InlineKeyboardButton(text="📈 Статистика", callback_data="stats"),
+    )
+    builder.row(
+        InlineKeyboardButton(text="❓ Помощь", callback_data="help"),
+        InlineKeyboardButton(text="ℹ️ О боте", callback_data="about"),
+    )
+    return builder.as_markup()
+
+
+def get_confirmation_keyboard(yes: str, no: str) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.row(
+        InlineKeyboardButton(text="✅ Да", callback_data=yes),
+        InlineKeyboardButton(text="❌ Нет", callback_data=no),
+    )
+    return builder.as_markup()

--- a/crypto_bot/src/bot/middlewares/database_mw.py
+++ b/crypto_bot/src/bot/middlewares/database_mw.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Middleware that injects database session into handlers."""
+
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from data.database import get_engine
+from utils.logger import LoggerMixin
+from utils.performance_utils import TimingContext
+
+
+class DatabaseMiddleware(BaseMiddleware, LoggerMixin):
+    """Create a new DB session for each update and measure performance."""
+
+    def __init__(self, sessionmaker: async_sessionmaker | None = None) -> None:
+        super().__init__()
+        if sessionmaker is None:
+            engine = get_engine()
+            self.sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        else:
+            self.sessionmaker = sessionmaker
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: Dict[str, Any],
+    ) -> Any:
+        async with self.sessionmaker() as session:  # type: AsyncSession
+            data["session"] = session
+            try:
+                with TimingContext() as tc:
+                    result = await handler(event, data)
+                if tc.elapsed_ms > 100:
+                    self.logger.warning("slow_db_handler", elapsed_ms=tc.elapsed_ms)
+                await session.commit()
+                return result
+            except Exception as exc:  # pragma: no cover - error path
+                await session.rollback()
+                self.logger.error("db_error", error=str(exc))
+                raise
+
+
+__all__ = ["DatabaseMiddleware"]

--- a/crypto_bot/src/config/bot_config.py
+++ b/crypto_bot/src/config/bot_config.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Pydantic settings for bot configuration."""
+
+from typing import Dict, List
+
+from pydantic_settings import BaseSettings
+
+
+class BotConfig(BaseSettings):
+    bot_token: str
+    debug: bool = False
+    log_level: str = "INFO"
+    max_connections: int = 100
+    request_timeout: int = 30
+
+    # Real-time settings
+    real_time_enabled: bool = True
+    real_time_performance_monitoring: bool = True
+    real_time_alerts_enabled: bool = True
+
+    max_pairs_per_user: int = 50
+    max_real_time_pairs: int = 20
+    notification_rate_limit: int = 10
+
+    default_timeframes: List[str] = ["1m", "5m", "15m", "1h", "4h", "1d"]
+    default_pair: str = "BTCUSDT"
+
+    rsi_period: int = 14
+    rsi_oversold_strong: float = 20
+    rsi_oversold_normal: float = 30
+    rsi_overbought_normal: float = 70
+    rsi_overbought_strong: float = 80
+
+    class Config:
+        env_file = ".env"
+
+    # Helper methods
+    def get_rsi_zones(self) -> Dict[str, float]:
+        return {
+            "oversold_strong": self.rsi_oversold_strong,
+            "oversold": self.rsi_oversold_normal,
+            "overbought": self.rsi_overbought_normal,
+            "overbought_strong": self.rsi_overbought_strong,
+        }
+
+    def validate_config(self) -> None:
+        if not self.bot_token:
+            raise ValueError("Bot token is required")
+
+    def is_real_time_enabled(self) -> bool:
+        return self.real_time_enabled
+
+    def get_performance_targets(self) -> Dict[str, int]:
+        return {
+            "websocket_processing": 10,
+            "rsi_calculation": 100,
+            "ema_calculation": 50,
+            "signal_generation": 200,
+            "notification_delivery": 500,
+            "total_processing": 1000,
+        }

--- a/crypto_bot/src/main.py
+++ b/crypto_bot/src/main.py
@@ -9,32 +9,45 @@ import asyncio
 import signal
 import sys
 from typing import Optional
-from contextlib import asynccontextmanager
 
-# Основные импорты будут добавлены в следующих блоках
-# Пока создаем базовую структуру
+from aiogram import Bot, Dispatcher
+
+from bot.handlers.add_pair.add_pair_handler import register_add_pair_handlers
+from bot.handlers.my_pairs.my_pairs_handler import register_my_pairs_handlers
+from bot.handlers.remove_pair_handler import register_remove_pair_handlers
+from bot.handlers.start_handler import register_start_handlers, stream_manager as start_stream_manager
+from bot.middlewares.database_mw import DatabaseMiddleware
+from config.bot_config import BotConfig
+from services.websocket.stream_manager import StreamManager
 
 # Глобальные переменные для сервисов
-bot: Optional[object] = None
-dp: Optional[object] = None
-stream_manager: Optional[object] = None
+bot: Optional[Bot] = None
+dp: Optional[Dispatcher] = None
+stream_manager: Optional[StreamManager] = None
 telegram_sender: Optional[object] = None
 real_time_processor: Optional[object] = None
 performance_monitor: Optional[object] = None
 
+stream_manager = start_stream_manager
 
-async def create_bot() -> object:
+
+async def create_bot() -> Bot:
     """Создать и настроить экземпляр Telegram бота"""
-    print("🤖 Creating bot instance...")
-    # Будет реализовано в следующих блоках
-    return None
+
+    cfg = BotConfig()
+    return Bot(cfg.bot_token, parse_mode="HTML")
 
 
-async def setup_dispatcher() -> object:
+async def setup_dispatcher(bot: Bot) -> Dispatcher:
     """Настроить диспетчер и зарегистрировать все обработчики"""
-    print("⚙️ Setting up dispatcher...")
-    # Будет реализовано в следующих блоках
-    return None
+
+    dispatcher = Dispatcher()
+    dispatcher.message.middleware(DatabaseMiddleware())
+    register_start_handlers(dispatcher)
+    register_add_pair_handlers(dispatcher)
+    register_my_pairs_handlers(dispatcher)
+    register_remove_pair_handlers(dispatcher)
+    return dispatcher
 
 
 def validate_application_config() -> None:
@@ -112,7 +125,7 @@ async def main() -> None:
         # Создание бота и диспетчера
         global bot, dp
         bot = await create_bot()
-        dp = await setup_dispatcher()
+        dp = await setup_dispatcher(bot)
 
         # Инициализация всех сервисов
         await init_services()

--- a/crypto_bot/src/utils/constants.py
+++ b/crypto_bot/src/utils/constants.py
@@ -2,6 +2,16 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+# Common emoji used across the bot interface
+EMOJI: Dict[str, str] = {
+    "add": "➕",
+    "pairs": "📊",
+    "remove": "❌",
+    "settings": "⚙️",
+    "back": "🔙",
+    "real_time": "⚡",
+}
+
 EMA_PERIODS: List[int] = [20, 50, 100, 200]
 
 PERFORMANCE_ALERT_THRESHOLDS = {"warning": 1.5, "critical": 2.0}


### PR DESCRIPTION
## Summary
- implement start command handler with user registration and default pair setup
- add basic pair management handlers, keyboards and logic
- introduce DB session middleware and bot configuration

## Testing
- `python -m py_compile crypto_bot/src/bot/handlers/start_handler.py crypto_bot/src/bot/handlers/add_pair/add_pair_handler.py crypto_bot/src/bot/handlers/add_pair/add_pair_logic.py crypto_bot/src/bot/handlers/my_pairs/my_pairs_handler.py crypto_bot/src/bot/handlers/my_pairs/my_pairs_formatters.py crypto_bot/src/bot/handlers/my_pairs/my_pairs_keyboards.py crypto_bot/src/bot/handlers/remove_pair_handler.py crypto_bot/src/bot/keyboards/main_menu_kb.py crypto_bot/src/bot/middlewares/database_mw.py crypto_bot/src/config/bot_config.py crypto_bot/src/main.py`
- `python -m py_compile $(git ls-files '*.py')` *(fails: from __future__ imports must occur at the beginning of the file)*

------
https://chatgpt.com/codex/tasks/task_e_688b5f4ce368832bb20e6b4330f5713d